### PR TITLE
Allows for the skip_gw option to be passed when creating a payment method

### DIFF
--- a/lib/killbill_client/models/payment_method.rb
+++ b/lib/killbill_client/models/payment_method.rb
@@ -66,15 +66,15 @@ module KillBillClient
       end
 
       def create(is_default, user = nil, reason = nil, comment = nil, options = {})
+        params = { :isDefault => is_default }
+        params[:pluginProperty] = 'skip_gw=true' if options[:skip_gw].present?
         created_pm = self.class.post "#{Account::KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/paymentMethods",
                                      to_json,
-                                     {
-                                         :isDefault => is_default
-                                     },
+                                     params,
                                      {
                                          :user => user,
                                          :reason => reason,
-                                         :comment => comment,
+                                         :comment => comment
                                      }.merge(options)
         created_pm.refresh(options)
       end


### PR DESCRIPTION
This PR allows for the `skip_gw` option to be passed to `KillBillClient::Model::PaymentMethod#create`. For example:

```ruby
payment_method = KillBillClient::Model::PaymentMethod.new
payment_method.plugin_name = 'killbill-stripe'
payment_method.plugin_info = { ... }
payment_method.account_id = '<my account ID>'
payment_method.create(true, KillBillClient.api_key, nil, nil, skip_gw: true)
```
