### PR TITLE
Adding PaymentMethod::EXTERNAL_PAYMENT constant

### DIFF
--- a/lib/killbill_client/models/payment_method.rb
+++ b/lib/killbill_client/models/payment_method.rb
@@ -2,6 +2,7 @@ module KillBillClient
   module Model
     class PaymentMethod < PaymentMethodAttributes
       KILLBILL_API_PAYMENT_METHODS_PREFIX = "#{KILLBILL_API_PREFIX}/paymentMethods"
+      EXTERNAL_PAYMENT = '__EXTERNAL_PAYMENT__'.freeze
 
       has_many :audit_logs, KillBillClient::Model::AuditLog
 

--- a/spec/killbill_client/remote/model_spec.rb
+++ b/spec/killbill_client/remote/model_spec.rb
@@ -94,7 +94,7 @@ describe KillBillClient::Model do
     pm = KillBillClient::Model::PaymentMethod.new
     pm.account_id = account.account_id
     pm.is_default = true
-    pm.plugin_name = '__EXTERNAL_PAYMENT__'
+    pm.plugin_name = KillBillClient::Model::PaymentMethod::EXTERNAL_PAYMENT
     pm.plugin_info = {}
     pm.payment_method_id.should be_nil
 


### PR DESCRIPTION
This PR adds a helpful `EXTERNAL_PAYMENT` constant to the `PaymentMethod` model class, so that we don't have to keep hardcoding the magic `__EXTERNAL_PAYMENT__` string.