### PR TITLE
Fixing Account#remove_auto_pay_off

### DIFF
--- a/lib/killbill_client/models/account.rb
+++ b/lib/killbill_client/models/account.rb
@@ -118,7 +118,7 @@ module KillBillClient
       end
 
       def remove_auto_pay_off(user = nil, reason = nil, comment = nil, options = {})
-        remove_tag_from_definition_id(AUTO_PAY_OFF_ID.id, user, reason, comment, options)
+        remove_tag_from_definition_id(AUTO_PAY_OFF_ID, user, reason, comment, options)
       end
 
       def auto_invoicing_off?(options = {})


### PR DESCRIPTION
I'm getting the following exception when attempting to call `KillBillClient::Model::Account#remove_auto_pay_off`:

```
NoMethodError: undefined method `id' for "00000000-0000-0000-0000-000000000001":String
from /usr/local/var/rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/bundler/gems/killbill-client-ruby-7cab229fb34b/lib/killbill_client/models/account.rb:121:in `remove_auto_pay_off'
```

This is because of the `AUTO_PAY_OFF_ID.id` call, which I think is just a typo.