### PR TITLE
Fixing calls to Account#control_tag_off? exceptions

### DIFF
--- a/lib/killbill_client/models/account.rb
+++ b/lib/killbill_client/models/account.rb
@@ -110,7 +110,7 @@ module KillBillClient
       end
 
       def auto_pay_off?(options = {})
-        control_tag_off?(AUTO_PAY_OFF_ID, options)
+        control_tag?(AUTO_PAY_OFF_ID, options)
       end
 
       def set_auto_pay_off(user = nil, reason = nil, comment = nil, options = {})
@@ -122,7 +122,7 @@ module KillBillClient
       end
 
       def auto_invoicing_off?(options = {})
-        control_tag_off?(AUTO_INVOICING_OFF_ID, options)
+        control_tag?(AUTO_INVOICING_OFF_ID, options)
       end
 
       def set_auto_invoicing_off(user = nil, reason = nil, comment = nil, options = {})
@@ -134,7 +134,7 @@ module KillBillClient
       end
 
       def overdue_enforcement_off?(options = {})
-        control_tag_off?(OVERDUE_ENFORCEMENT_OFF_ID, options)
+        control_tag?(OVERDUE_ENFORCEMENT_OFF_ID, options)
       end
 
       def set_overdue_enforcement_off(user = nil, reason = nil, comment = nil, options = {})
@@ -146,7 +146,7 @@ module KillBillClient
       end
 
       def written_off?(options = {})
-        control_tag_off?(WRITTEN_OFF_ID, options)
+        control_tag?(WRITTEN_OFF_ID, options)
       end
 
       def set_written_off(user = nil, reason = nil, comment = nil, options = {})
@@ -158,7 +158,7 @@ module KillBillClient
       end
 
       def manual_pay?(options = {})
-        control_tag_off?(MANUAL_PAY_ID, options)
+        control_tag?(MANUAL_PAY_ID, options)
       end
 
       def set_manual_pay(user = nil, reason = nil, comment = nil, options = {})
@@ -170,7 +170,7 @@ module KillBillClient
       end
 
       def test?(options = {})
-        control_tag_off?(TEST_ID, options)
+        control_tag?(TEST_ID, options)
       end
 
       def set_test(user = nil, reason = nil, comment = nil, options = {})

--- a/lib/killbill_client/models/helpers/tag_helper.rb
+++ b/lib/killbill_client/models/helpers/tag_helper.rb
@@ -55,11 +55,10 @@ module KillBillClient
         remove_tags_from_definition_ids([tag_definition_id], user, reason, comment, options)
       end
 
-      def control_tag_off?(control_tag_definition_id, options)
-        res = tags('NONE', options)
-        !((res || []).select do |t|
+      def control_tag?(control_tag_definition_id, options)
+        tags(false, 'NONE', options).any? do |t|
           t.tag_definition_id == control_tag_definition_id
-        end.first.nil?)
+        end
       end
 
       module ClassMethods


### PR DESCRIPTION
Calling `Account#control_tag_off?` (and any other method that calls it under the hood, like `Account#auto_pay_off?`) results in a `KillBillClient::API::NotFound` exception. This is because the parameters passed to `KillBillClient::Model::TagHelper#tags` are not correct. This PR adds the correct parameters for that call.

It also does a couple other things:

* Renames the `control_tag_off?` method to `control_tag?`. The name of this method was really confusing--does it indicate that the entity does _not_ have the given tag? The new method checks instead for the _presence_ of the given tag, and is named appropriately.
* Simplifies the logic of the former `control_tag_off?` method using the `Array#any?` method.

If you'd like me to roll back the other two more aggressive changes and just implement the fix for the `tag` method parameters, let me know and I can do that.

Thanks!