### PR TITLE
Adding support for acronyms when camelizing attribute names

### DIFF
--- a/lib/killbill_client/utils.rb
+++ b/lib/killbill_client/utils.rb
@@ -1,13 +1,16 @@
 module KillBillClient
   module Utils
+    ACRONYMS = %w(CBA).freeze
+
     def camelize(underscored_word, first_letter = :upper)
-      camelized = underscored_word.to_s.gsub(/(?:^|_)(.)/) { $1.upcase }
-      case first_letter
-        when :lower then
-          camelized = camelized[0, 1].downcase + camelized[1..-1]
+      camelized = underscored_word.to_s.split('_').map do |word|
+        if acronym?(word)
+          word.upcase
         else
-          # camelized = camelized
-      end
+          word[0, 1].upcase + word[1..-1]
+        end
+      end.join
+      camelized = camelized[0, 1].downcase + camelized[1..-1] if first_letter == :lower
       camelized
     end
 
@@ -23,6 +26,10 @@ module KillBillClient
       word.tr! '-', '_'
       word.downcase!
       word
+    end
+
+    def acronym?(word)
+      ACRONYMS.include?(word.to_s.upcase)
     end
 
     extend self


### PR DESCRIPTION
Certain attributes that contained acronyms were not being serialized correctly (`accountCBA` for example), leading to errors like the following when updating an account:

```
KillBillClient::API::BadRequest: {"className":"com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException","code":null,"message":"Unrecognized field \"accountCba\" (class org.killbill.billing.jaxrs.json.AccountJson), not marked as ignorable (23 known properties: \"paymentMethodId\", \"name\", \"isNotifiedForInvoices\", \"currency\", \"state\", \"externalKey\", \"country\", \"postalCode\", \"timeZone\", \"locale\", \"email\", \"firstNameLength\", \"isMigrated\", \"accountId\" [truncated]])\n at [Source: org.apache.catalina.connector.CoyoteInputStream@596e8b96; line: 1, column: 525] (through reference chain: org.killbill.billing.jaxrs.json.AccountJson[\"accountCba\"])","causeClassName":null,"causeMessage":null,"stackTrace":[]}
from killbill-client-0.15.0/lib/killbill_client/api/net_http_adapter.rb:188:in `request'
```

This commit adds the ability to specify a list of acronyms that will be taken into account when camelizing attributes (and other words).