### PR TITLE
Uses the standard X-Request-Id header

### DIFF
--- a/lib/killbill_client/api/net_http_adapter.rb
+++ b/lib/killbill_client/api/net_http_adapter.rb
@@ -122,7 +122,7 @@ module KillBillClient
           end
 
           if options[:request_id]
-            request['X-Killbill-Request-Id-Req'] = options[:request_id]
+            request['X-Request-Id'] = options[:request_id]
           end
 
           http = ::Net::HTTP.new uri.host, uri.port


### PR DESCRIPTION
Instead of `X-Killbill-Request-Id-Req`, to transmit the `request_id` option.