### PR TITLE
Find payments with plugin info

### DIFF
--- a/lib/killbill_client/models/payment.rb
+++ b/lib/killbill_client/models/payment.rb
@@ -13,10 +13,6 @@ module KillBillClient
 
       class << self
         def find_by_id(payment_id, with_plugin_info = false, options = {})
-          if with_plugin_info.is_a? Hash
-            options = with_plugin_info
-            with_plugin_info = false
-          end
           get "#{KILLBILL_API_PAYMENTS_PREFIX}/#{payment_id}",
               {
                   :withPluginInfo => with_plugin_info
@@ -25,10 +21,6 @@ module KillBillClient
         end
 
         def find_by_external_key(external_key, with_plugin_info = false, options = {})
-          if with_plugin_info.is_a? Hash
-            options = with_plugin_info
-            with_plugin_info = false
-          end
           get "#{KILLBILL_API_PAYMENTS_PREFIX}",
               {
                   :externalKey => external_key,

--- a/lib/killbill_client/models/payment.rb
+++ b/lib/killbill_client/models/payment.rb
@@ -12,16 +12,27 @@ module KillBillClient
       has_custom_fields KILLBILL_API_PAYMENTS_PREFIX, :payment_id
 
       class << self
-        def find_by_id(payment_id, options = {})
+        def find_by_id(payment_id, with_plugin_info = false, options = {})
+          if with_plugin_info.is_a? Hash
+            options = with_plugin_info
+            with_plugin_info = false
+          end
           get "#{KILLBILL_API_PAYMENTS_PREFIX}/#{payment_id}",
-              {},
+              {
+                  :withPluginInfo => with_plugin_info
+              },
               options
         end
 
-        def find_by_external_key(external_key, options = {})
+        def find_by_external_key(external_key, with_plugin_info = false, options = {})
+          if with_plugin_info.is_a? Hash
+            options = with_plugin_info
+            with_plugin_info = false
+          end
           get "#{KILLBILL_API_PAYMENTS_PREFIX}",
               {
-                  :externalKey => external_key
+                  :externalKey => external_key,
+                  :withPluginInfo => with_plugin_info
               },
               options
         end


### PR DESCRIPTION
Extends Payment's find_* methods, adding the with_plugin_info argument