### PR TITLE
Fixes Location following for error responses

### DIFF
--- a/lib/killbill_client/models/combo_transaction.rb
+++ b/lib/killbill_client/models/combo_transaction.rb
@@ -35,7 +35,8 @@ module KillBillClient
         rescue KillBillClient::API::ResponseError => error
           response = error.response
           if response.header['location']
-            created_transaction = self.class.from_response(response)
+            created_transaction = ComboTransaction.new
+            created_transaction.uri = response.header['location']
           else
             raise error
           end

--- a/lib/killbill_client/models/transaction.rb
+++ b/lib/killbill_client/models/transaction.rb
@@ -159,7 +159,8 @@ module KillBillClient
         rescue KillBillClient::API::ResponseError => error
           response = error.response
           if response.header['location']
-            created_transaction = self.class.from_response(response)
+            created_transaction = Transaction.new
+            created_transaction.uri = response.header['location']
           else
             raise error
           end


### PR DESCRIPTION
The `from_response` can't be used here since it doesn't check the location header if the response contains a body (even if it's an exception), so the uri attribute of the transaction was never set.

https://github.com/killbill/killbill-client-ruby/blob/master/lib/killbill_client/models/resource.rb#L84-L88
https://github.com/killbill/killbill-client-ruby/blob/master/lib/killbill_client/models/resource.rb#L114