### PR TITLE
Follow location flag + refresh options

### DIFF
--- a/lib/killbill_client/models/combo_transaction.rb
+++ b/lib/killbill_client/models/combo_transaction.rb
@@ -23,6 +23,8 @@ module KillBillClient
       private
 
       def combo_payment(user, reason, comment, options, refresh_options = nil)
+        follow_location = true
+        follow_location = options.delete(:follow_location) if options.has_key?(:follow_location)
         begin
           created_transaction = self.class.post "#{Payment::KILLBILL_API_PAYMENTS_PREFIX}/combo",
                                                 to_json,
@@ -34,14 +36,18 @@ module KillBillClient
                                                 }.merge(options)
         rescue KillBillClient::API::ResponseError => error
           response = error.response
-          if response.header['location']
+          if follow_location && response.header['location']
             created_transaction = ComboTransaction.new
             created_transaction.uri = response.header['location']
           else
             raise error
           end
         end
-        created_transaction.refresh(refresh_options || options, Payment)
+
+        if follow_location
+          return created_transaction.refresh(refresh_options || options, Payment)
+        end
+        created_transaction
       end
     end
   end

--- a/lib/killbill_client/models/combo_transaction.rb
+++ b/lib/killbill_client/models/combo_transaction.rb
@@ -47,7 +47,10 @@ module KillBillClient
         if follow_location
           return created_transaction.refresh(refresh_options || options, Payment)
         end
-        created_transaction
+
+        created_payment = Payment.new
+        created_payment.uri = created_transaction.uri
+        created_payment
       end
     end
   end

--- a/lib/killbill_client/models/transaction.rb
+++ b/lib/killbill_client/models/transaction.rb
@@ -201,7 +201,10 @@ module KillBillClient
         if follow_location
           return created_transaction.refresh(refresh_options, Payment)
         end
-        created_transaction
+
+        created_payment = Payment.new
+        created_payment.uri = created_transaction.uri
+        created_payment
       end
     end
   end


### PR DESCRIPTION
1. Allows the passing of the `follow_location` flag, to control if a payment should be refreshed using the `Location` header returned by a create transaction call (auth, capture, void, refund, etc)
2. Optional parameter for providing a `refresh_options` hash
