### PR TITLE
Remove Ruby warnings

### DIFF
--- a/killbill_client.gemspec
+++ b/killbill_client.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
 
   s.rdoc_options << '--exclude' << '.'
 
-  s.add_dependency 'json', '>= 1.2.0'
+  s.add_dependency 'json', '>= 1.2.0', '< 2.0.0'
 
   s.add_development_dependency 'rake', '>= 10.0.0', '< 11.0.0'
   s.add_development_dependency 'rspec', '~> 3.4'

--- a/lib/killbill_client/api/net_http_adapter.rb
+++ b/lib/killbill_client/api/net_http_adapter.rb
@@ -74,7 +74,7 @@ module KillBillClient
             # Note: make sure to keep the full path (if any) from URI::HTTP, for non-ROOT deployments
             # See https://github.com/killbill/killbill/issues/221#issuecomment-151980263
             base_path = uri.request_uri == '/' ? '' : uri.request_uri
-            uri += (base_path + URI.escape(relative_uri))
+            uri += (base_path + URI::DEFAULT_PARSER.escape(relative_uri))
           else
             uri = relative_uri
             uri = URI.parse(uri) unless uri.is_a?(URI)

--- a/lib/killbill_client/models/invoice.rb
+++ b/lib/killbill_client/models/invoice.rb
@@ -68,7 +68,7 @@ module KillBillClient
 
             res.refresh(options)
 
-          rescue KillBillClient::API::BadRequest => e
+          rescue KillBillClient::API::BadRequest
             # No invoice to generate : TODO parse json to verify this is indeed the case
           end
         end
@@ -94,7 +94,7 @@ module KillBillClient
 
             res.refresh(options)
 
-          rescue KillBillClient::API::NotFound => e
+          rescue KillBillClient::API::NotFound
             nil
           end
         end
@@ -126,7 +126,7 @@ module KillBillClient
                        Invoice
 
             res.refresh(options)
-          rescue KillBillClient::API::NotFound => e
+          rescue KillBillClient::API::NotFound
             nil
           end
         end
@@ -160,7 +160,7 @@ module KillBillClient
                        Invoice
 
             res.refresh(options)
-          rescue KillBillClient::API::NotFound => e
+          rescue KillBillClient::API::NotFound
             nil
           end
         end
@@ -193,7 +193,7 @@ module KillBillClient
 
             res.refresh(options)
 
-          rescue KillBillClient::API::NotFound => e
+          rescue KillBillClient::API::NotFound
             nil
           end
         end

--- a/lib/killbill_client/models/resources.rb
+++ b/lib/killbill_client/models/resources.rb
@@ -7,8 +7,8 @@ module KillBillClient
                   :session_id,
                   :pagination_max_nb_records,
                   :pagination_total_nb_records,
-                  :pagination_next_page
-                  :response
+                  :pagination_next_page,
+		  :response
 
       # Same as .each, but fetch remaining pages as we go
       def each_in_batches(&block)

--- a/lib/killbill_client/models/tenant.rb
+++ b/lib/killbill_client/models/tenant.rb
@@ -27,7 +27,7 @@ module KillBillClient
         end
 
         def delete_tenant_plugin_config(plugin_name, user = nil, reason = nil, comment = nil, options = {})
-          delete_tenant_user_key_value(plugin_name, "uploadPluginConfig", "plugin config", user, reason, comment, options)
+          delete_tenant_key_value(plugin_name, "uploadPluginConfig", "plugin config", user, reason, comment, options)
         end
 
         def get_tenant_user_key_value(key_name, options = {})
@@ -40,7 +40,7 @@ module KillBillClient
 
 
         def delete_tenant_user_key_value(key_name, user = nil, reason = nil, comment = nil, options = {})
-          delete_tenant_user_key_value(key_name, "userKeyValue", "tenant key/value", user, reason, comment, options)
+          delete_tenant_key_value(key_name, "userKeyValue", "tenant key/value", user, reason, comment, options)
         end
 
         def get_tenant_key_value(key_name, key_path, error_id_str, options = {})
@@ -75,7 +75,7 @@ module KillBillClient
         end
 
 
-        def delete_tenant_user_key_value(key_name, key_path, error_id_str, user = nil, reason = nil, comment = nil, options = {})
+        def delete_tenant_key_value(key_name, key_path, error_id_str, user = nil, reason = nil, comment = nil, options = {})
 
           require_multi_tenant_options!(options, "Deleting a #{error_id_str} is only supported in multi-tenant mode")
 

--- a/lib/killbill_client/models/transaction.rb
+++ b/lib/killbill_client/models/transaction.rb
@@ -164,9 +164,9 @@ module KillBillClient
           created_transaction = yield
         rescue KillBillClient::API::ResponseError => error
           response = error.response
-          if response.header['location']
+          if response['location']
             created_transaction = Transaction.new
-            created_transaction.uri = response.header['location']
+            created_transaction.uri = response['location']
           else
             raise error
           end


### PR DESCRIPTION
This is a list of changes to the client code to eliminate warnings and obsolescence notices emitted by 'ruby -w'. 

All specs pass. 