### PR TITLE
Fix methods: 'email_notifications', 'set_blocking_state', and 'invoice_payments'

### DIFF
--- a/lib/killbill_client/models/account.rb
+++ b/lib/killbill_client/models/account.rb
@@ -297,6 +297,65 @@ module KillBillClient
                        options,
                        CustomField
       end
+      def blocking_states(blocking_state_types, blocking_state_svcs, audit = 'NONE', options = {})
+        params = {}
+        params[:blockingStateTypes] = blocking_state_types if blocking_state_types
+        params[:blockingStateSvcs] = blocking_state_svcs if blocking_state_svcs
+        params[:audit] = audit
+        self.class.get "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/block",
+                       params,
+                       options
+      end
+
+      def block_account(state_name, service, block_change, block_entitlement, block_billing, requested_date = nil, user = nil, reason = nil, comment = nil, options = {})
+
+        params = {}
+        params[:requestedDate] = requested_date if requested_date
+
+        body = KillBillClient::Model::BlockingStateAttributes.new
+        body.state_name = state_name
+        body.service = service
+        body.block_change = block_change
+        body.block_entitlement = block_entitlement
+        body.block_billing = block_billing
+
+        self.class.put "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/block",
+                       body.to_json,
+                       params,
+                       {
+                           :user => user,
+                           :reason => reason,
+                           :comment => comment,
+                       }.merge(options)
+
+      end
+
+      def cba_rebalancing(user = nil, reason = nil, comment = nil, options = {})
+        self.class.post "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/cbaRebalancing",
+                        {},
+                        {},
+                        {
+                            :user    => user,
+                            :reason  => reason,
+                            :comment => comment,
+                        }.merge(options)
+      end
+
+      def email_notifications(options = {})
+        self.class.get "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/emailNotifications",
+                       {},
+                       options
+      end
+
+      def invoice_payments(audit='NONE', with_plugin_info = false, with_attempts = false, options = {})
+        self.class.get "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/invoicePayments",
+                       {
+                           :audit                    => audit,
+                           :withPluginInfo       => with_plugin_info,
+                           :withAttempts => with_attempts
+                       },
+                       options
+      end
     end
   end
 end

--- a/lib/killbill_client/models/account.rb
+++ b/lib/killbill_client/models/account.rb
@@ -268,7 +268,8 @@ module KillBillClient
       def email_notifications(options = {})
         self.class.get "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/emailNotifications",
                        {},
-                       options
+                       options,
+                       InvoiceEmailAttributes
       end
 
       def update_email_notifications(user = nil, reason = nil, comment = nil, options = {})
@@ -310,7 +311,9 @@ module KillBillClient
         params[:audit] = audit
         self.class.get "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/block",
                        params,
-                       options
+                       options,
+                       BlockingStateAttributes
+
       end
 
       def set_blocking_state(state_name, service, block_change, block_entitlement, block_billing, requested_date = nil, user = nil, reason = nil, comment = nil, options = {})
@@ -325,7 +328,7 @@ module KillBillClient
         body.block_entitlement = block_entitlement
         body.block_billing = block_billing
 
-        self.class.put "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/block",
+        blocking_state = self.class.put "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/block",
                        body.to_json,
                        params,
                        {
@@ -333,7 +336,7 @@ module KillBillClient
                            :reason => reason,
                            :comment => comment,
                        }.merge(options)
-
+        blocking_states(nil, nil, 'NONE', options)
       end
 
       def cba_rebalancing(user = nil, reason = nil, comment = nil, options = {})
@@ -354,7 +357,8 @@ module KillBillClient
                            :withPluginInfo       => with_plugin_info,
                            :withAttempts => with_attempts
                        },
-                       options
+                       options,
+                       InvoicePayment
       end
     end
   end

--- a/lib/killbill_client/models/account.rb
+++ b/lib/killbill_client/models/account.rb
@@ -265,6 +265,12 @@ module KillBillClient
                        AccountEmailAttributes
       end
 
+      def email_notifications(options = {})
+        self.class.get "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/emailNotifications",
+                       {},
+                       options
+      end
+
       def update_email_notifications(user = nil, reason = nil, comment = nil, options = {})
         self.class.put "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/emailNotifications",
                        to_json,
@@ -307,7 +313,7 @@ module KillBillClient
                        options
       end
 
-      def block_account(state_name, service, block_change, block_entitlement, block_billing, requested_date = nil, user = nil, reason = nil, comment = nil, options = {})
+      def set_blocking_state(state_name, service, block_change, block_entitlement, block_billing, requested_date = nil, user = nil, reason = nil, comment = nil, options = {})
 
         params = {}
         params[:requestedDate] = requested_date if requested_date
@@ -339,12 +345,6 @@ module KillBillClient
                             :reason  => reason,
                             :comment => comment,
                         }.merge(options)
-      end
-
-      def email_notifications(options = {})
-        self.class.get "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/emailNotifications",
-                       {},
-                       options
       end
 
       def invoice_payments(audit='NONE', with_plugin_info = false, with_attempts = false, options = {})

--- a/lib/killbill_client/models/account.rb
+++ b/lib/killbill_client/models/account.rb
@@ -304,6 +304,7 @@ module KillBillClient
                        options,
                        CustomField
       end
+
       def blocking_states(blocking_state_types, blocking_state_svcs, audit = 'NONE', options = {})
         params = {}
         params[:blockingStateTypes] = blocking_state_types if blocking_state_types


### PR DESCRIPTION
Fix return values to methods: 'email_notifications', 'set_blocking_state', and 'invoice_payments'
Ref  [killbill-client-ruby Issue #36](https://github.com/killbill/killbill-client-ruby/issues/36)