### PR TITLE
Create entitlement with seperate dates

### DIFF
--- a/lib/killbill_client/models/subscription.rb
+++ b/lib/killbill_client/models/subscription.rb
@@ -64,7 +64,35 @@ module KillBillClient
                                               }.merge(options)
         created_entitlement.refresh(options)
       end
+      #
+      # Create a new entitlement with different entitlement and billing date
+      #
+      #
+      #
+      def create_with_entitlement_date(user = nil, 
+                                  reason = nil, 
+                                  comment = nil, 
+                                  entitlement_date = nil,
+                                  billing_date = nil,
+                                  call_completion = false, 
+                                  options = {})
 
+        params                  = {}
+        params[:callCompletion] = call_completion
+        params[:entitlementDate]  = entitlement_date unless entitlement_date.nil?
+        params[:billingDate]  = billing_date unless billing_date.nil?
+
+
+        created_entitlement = self.class.post KILLBILL_API_ENTITLEMENT_PREFIX,
+                                              to_json,
+                                              params,
+                                              {
+                                                  :user    => user,
+                                                  :reason  => reason,
+                                                  :comment => comment,
+                                              }.merge(options)
+        created_entitlement.refresh(options)
+      end
       #
       # Change the plan of the existing Entitlement
       #


### PR DESCRIPTION
Regarding

https://groups.google.com/forum/#!topic/killbilling-users/whedUz7u0ms

When i am creating multiple subscriptions at the same time or creating a base subscription, i can use "create_entitlement_with_add_on" and set both the billing and entitlement date.

But when i wish to add an addon-subscription to en existing base-subscription i could not find a way to have separate entitlement and billling dates as the current "create" method only uses a single date.

This method seems to work. There is perhaps a different way im supposed to do it.