### PR TITLE
client: add support for Bearer Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,37 @@ Alternatively, add the dependency in your Gemfile:
 gem 'killbill-client', '~> 1.0'
 ```
 
+Authentication
+--------------
+
+A username and password can be set directly in the `options` hash (accepted by each API method):
+```ruby
+options = {
+  :username => 'admin',
+  :password => 'password'
+}
+```
+These credentials are validated by Kill Bill either directly (users managed by Kill Bill) or via a third-party (LDAP, Okta, Auth0, etc.).
+
+Alternatively, a bearer token can be passed as such:
+```ruby
+options = {
+  :bearer => 'token'
+}
+```
+The security token would be validated by Kill bill via a third-party (e.g. Auth0).
+
+By default, Kill Bill won't maintain sessions, except when calling the API `/1.0/kb/security/permissions` (`JSESSIONID`, present in the `Set-Cookie` response header).
+This session id can be passed instead:
+```ruby
+options = {
+  :session_id => 'JSESSIONID'
+}
+```
+Using this session mechanism is recommend for user interfaces or to minimize the runtime dependency with a third-party provider.
+
+Note: if a timed out session is re-used (`last_access_time` older than 60 minutes by default), a `HTTP/1.1 401 Unauthorized` is returned with `Set-Cookie: JSESSIONID=deleteMe`, and the session is deleted from the database (and cache) on the server side.
+
 Examples
 --------
 

--- a/lib/killbill_client/api/net_http_adapter.rb
+++ b/lib/killbill_client/api/net_http_adapter.rb
@@ -118,8 +118,11 @@ module KillBillClient
           # Configure RBAC, if enabled
           username = options[:username] || KillBillClient.username
           password = options[:password] || KillBillClient.password
+          bearer = options[:bearer]
           if username and password
             request.basic_auth(*[username, password].flatten[0, 2])
+          elsif bearer
+            request['authorization'] = 'Bearer ' + bearer
           end
           session_id = options[:session_id]
           if session_id


### PR DESCRIPTION
Required to support JWT tokens in Kaui (Auth0 integration).