### PR TITLE
Fix integration test failure

### DIFF
--- a/lib/killbill_client/models/catalog.rb
+++ b/lib/killbill_client/models/catalog.rb
@@ -148,7 +148,7 @@ module KillBillClient
                    :reason => reason,
                    :comment => comment,
                }.merge(options)
-          get_tenant_catalog_json(nil, options)
+          get_tenant_catalog_json(nil, nil, options)
         end
 
 


### PR DESCRIPTION
There was a recent change done as part of https://github.com/killbill/killbill-client-ruby/pull/86 that introduced a regression causing Kill Bill integration tests to [fail](https://github.com/killbill/killbill/actions/runs/5327485947/jobs/9650937682). This PR attempts to fix this.