### PR TITLE
Issue 120 Fix bug Invoices tab show Amount and Balance as 0

### DIFF
--- a/lib/killbill_client/models/account.rb
+++ b/lib/killbill_client/models/account.rb
@@ -147,7 +147,7 @@ module KillBillClient
         self.class.get "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/invoices",
                        {
                            :includeInvoiceComponents => true
-                       },
+                       }.merge(options.delete(:params)),
                        options,
                        Invoice
       end


### PR DESCRIPTION
The issue is here: https://github.com/killbill/killbill-admin-ui/blob/3cc81f7239f4223f120f380a891ef1c69f17ac1b/app/controllers/kaui/invoices_controller.rb#L27
When we pass the params inside the options, it will override the default params from killbill-ruby-clients.
https://github.com/killbill/killbill-client-ruby/blob/0c897c2006f5a8e22bbc98176e91200ff02253cd/lib/killbill_client/api/api.rb#L43C17-L43C17

In this case, the params will be **includeVoidedInvoices: true** instead of **includeInvoiceComponents: true**