### PR TITLE
Fix for integration test failure

### DIFF
--- a/lib/killbill_client/models/account.rb
+++ b/lib/killbill_client/models/account.rb
@@ -144,12 +144,13 @@ module KillBillClient
       end
 
       def invoices(options = {})
+        params_hash = options.delete(:params)
+        options_to_merge = params_hash.nil? ? {} : params_hash
+        merged_options = { :includeInvoiceComponents => true }.merge(options_to_merge)
         self.class.get "#{KILLBILL_API_ACCOUNTS_PREFIX}/#{account_id}/invoices",
-                       {
-                           :includeInvoiceComponents => true
-                       }.merge(options.delete(:params)),
-                       options,
-                       Invoice
+                 merged_options,
+                 options,
+                 Invoice
       end
 
       def migration_invoices(options = {})


### PR DESCRIPTION
Fix for [integration test failure](https://github.com/killbill/killbill/actions/runs/7188808294/job/19584161060#step:18:34). 

More details about this fix: 

The integration tests fail [here](https://github.com/killbill/killbill-integration-tests/blob/51968e42011ffb574b9046fe7b2a228deb803253/killbill-integration-tests/test_base.rb#L63) due to the following error:

```
 TypeError: no implicit conversion of nil into Hash
```

On debugging this further, I found that [this change](https://github.com/killbill/killbill-client-ruby/pull/91) was made recently which causes this error. This PR attempts to fix this error. 

