### PR TITLE
Add CustomFields to PaymentMethod and Transactions

### DIFF
--- a/lib/killbill_client/models/payment_method.rb
+++ b/lib/killbill_client/models/payment_method.rb
@@ -2,6 +2,7 @@ module KillBillClient
   module Model
     class PaymentMethod < PaymentMethodAttributes
 
+      include KillBillClient::Model::CustomFieldHelper
       include KillBillClient::Model::AuditLogWithHistoryHelper
 
       KILLBILL_API_PAYMENT_METHODS_PREFIX = "#{KILLBILL_API_PREFIX}/paymentMethods"
@@ -10,6 +11,7 @@ module KillBillClient
       has_many :audit_logs, KillBillClient::Model::AuditLog
 
       has_audit_logs_with_history KILLBILL_API_PAYMENT_METHODS_PREFIX, :payment_method_id
+      has_custom_fields KILLBILL_API_PAYMENT_METHODS_PREFIX, :payment_method_id
 
       class << self
         def find_by_id(payment_method_id, with_plugin_info = false, options = {})

--- a/lib/killbill_client/models/transaction.rb
+++ b/lib/killbill_client/models/transaction.rb
@@ -4,6 +4,7 @@ module KillBillClient
   module Model
     class Transaction < PaymentTransactionAttributes
 
+      include KillBillClient::Model::CustomFieldHelper
       include KillBillClient::Model::AuditLogWithHistoryHelper
 
       KILLBILL_API_TRANSACTIONS_PREFIX = "#{KILLBILL_API_PREFIX}/paymentTransactions"
@@ -12,6 +13,7 @@ module KillBillClient
       has_many :audit_logs, KillBillClient::Model::AuditLog
 
       has_audit_logs_with_history KILLBILL_API_TRANSACTIONS_PREFIX, :transaction_id
+      has_custom_fields KILLBILL_API_TRANSACTIONS_PREFIX, :transaction_id
 
       def auth(account_id, payment_method_id = nil, user = nil, reason = nil, comment = nil, options = {}, refresh_options = nil)
         @transaction_type = 'AUTHORIZE'


### PR DESCRIPTION
Related ticket: https://github.com/killbill/killbill-client-ruby/issues/89
Fixed in this pull request:  
- Payment methods custom fields section - None of the code snippets in this section work. They cause a  undefined method error. I think this is because payment_method.rb does not include CustomFieldHelper as done in subscription.rb.
- Add Payment Method Custom Field and Delete Payment Method Custom Field - These endpoints need to be updated to allow creating/deleting multiple custom fields
- Payment transaction custom fields section - None of the code snippets in this section work. They cause a  undefined method error. I think this is because transaction.rb does not include CustomFieldHelper as done in subscription.rb.
