### PR TITLE
Issue 89 Add TagsHelper to Transaction

### DIFF
--- a/lib/killbill_client/models/transaction.rb
+++ b/lib/killbill_client/models/transaction.rb
@@ -14,6 +14,7 @@ module KillBillClient
 
       has_audit_logs_with_history KILLBILL_API_TRANSACTIONS_PREFIX, :transaction_id
       has_custom_fields KILLBILL_API_TRANSACTIONS_PREFIX, :transaction_id
+      has_tags KILLBILL_API_TRANSACTIONS_PREFIX, :transaction_id
 
       def auth(account_id, payment_method_id = nil, user = nil, reason = nil, comment = nil, options = {}, refresh_options = nil)
         @transaction_type = 'AUTHORIZE'


### PR DESCRIPTION
Here is the ticket: https://github.com/killbill/killbill-client-ruby/issues/89
Update:
- Add TagHelper to Transaction