### PR TITLE
Issue 89 Support external key

### DIFF
--- a/lib/killbill_client/models/transaction.rb
+++ b/lib/killbill_client/models/transaction.rb
@@ -125,7 +125,11 @@ module KillBillClient
                                 :reason  => reason,
                                 :comment => comment,
                             }.merge(options)
-          KillBillClient::Model::Payment.find_by_id(payment_id, false, false, options)
+          if payment_external_key
+            KillBillClient::Model::Payment.find_by_external_key(payment_external_key, false, false, options)
+          else
+            KillBillClient::Model::Payment.find_by_id(payment_id, false, false, options)
+          end
         end
       end
 
@@ -225,7 +229,11 @@ module KillBillClient
                              :reason => reason,
                              :comment => comment
                          }.merge(options)
-          KillBillClient::Model::Payment.find_by_id(payment_id, false, false, options)
+          if payment_external_key
+            KillBillClient::Model::Payment.find_by_external_key(payment_external_key, false, false, options)
+          else
+            KillBillClient::Model::Payment.find_by_id(payment_id, false, false, options)
+          end
         end
       end
 


### PR DESCRIPTION
Related issue: https://github.com/orgs/killbill/projects/22/views/1?pane=issue&itemId=53996249
Update:

[Complete existing transaction using payment external key](https://killbill.github.io/slate/payment.html#complete-an-existing-transaction-using-paymentexternalkey) - This API endpoint allows completing an existing transaction using the payment external key ( without payment ID ). However, the Ruby code errors out, though the transaction gets updated correctly.
[Void existing transaction using payment external key](https://killbill.github.io/slate/payment.html#void-an-existing-payment-using-paymentexternalkey) - This API endpoint allows to void an existing transaction using the payment external key ( without payment ID ). However, the Ruby code errors out, though the transaction gets updated correctly.