### PR TITLE
Issue 88 Mark a pending payment transaction as succeeded or failed

### DIFF
--- a/lib/killbill_client/models/transaction.rb
+++ b/lib/killbill_client/models/transaction.rb
@@ -193,6 +193,17 @@ module KillBillClient
           end
       end
 
+      def update_transaction_state(status, control_plugin_name = nil, user, reason, comment, options)
+        self.class.post "KILLBILL_API_TRANSACTIONS_PREFIX/#{transaction_id}",
+                       {:paymentId => payment_id, :status => status}.to_json,
+                       {:controlPluginName => (control_plugin_name || [])},
+                       {
+                          :user => user,
+                          :reason => reason,
+                          :comment => comment
+                       }.merge(options)
+      end
+
       private
 
 


### PR DESCRIPTION
Related issue: https://github.com/killbill/killbill-client-ruby/issues/88
Updates: 
Mark a pending payment transaction as succeeded or failed