### PR TITLE
Issue 88 Add new Role Apis

### DIFF
--- a/lib/killbill_client/models/role_definition.rb
+++ b/lib/killbill_client/models/role_definition.rb
@@ -2,6 +2,14 @@ module KillBillClient
   module Model
     class RoleDefinition < RoleDefinitionAttributes
 
+      class << self
+        def find_by_name(role_name, options = {})
+          role = get "#{Security::KILLBILL_API_SECURITY_PREFIX}/roles/#{role_name}",
+                                        {},
+                                        options
+        end
+      end
+
       def create(user = nil, reason = nil, comment = nil, options = {})
         created_role = self.class.post "#{Security::KILLBILL_API_SECURITY_PREFIX}/roles",
                                        to_json,
@@ -12,6 +20,17 @@ module KillBillClient
                                            :comment => comment,
                                        }.merge(options)
         created_role.refresh(options)
+      end
+
+      def update(user = nil, reason = nil, comment = nil, options = {})
+        self.class.put "#{Security::KILLBILL_API_SECURITY_PREFIX}/roles",
+                                       to_json,
+                                       {},
+                                       {
+                                           :user => user,
+                                           :reason => reason,
+                                           :comment => comment,
+                                       }.merge(options)
       end
     end
   end


### PR DESCRIPTION
Related issue: https://github.com/killbill/killbill-client-ruby/issues/88
- Update an existing role permissions
- Retrieve Role definition