### PR TITLE
Avoid double encode for encoded string

### DIFF
--- a/lib/killbill_client/api/net_http_adapter.rb
+++ b/lib/killbill_client/api/net_http_adapter.rb
@@ -37,14 +37,14 @@ module KillBillClient
 
         def build_uri(relative_uri, options)
           # Need to encode in case of spaces (e.g. /1.0/kb/security/users/Mad Max/roles)
-          encoded_relative_uri = URI::DEFAULT_PARSER.escape(relative_uri)
+          encoded_relative_uri = URI::DEFAULT_PARSER.regexp[:UNSAFE].match?(relative_uri) ? relative_uri : URI::DEFAULT_PARSER.escape(relative_uri)
           if URI(encoded_relative_uri).scheme.nil?
             uri = (options[:base_uri] || KillBillClient::API.base_uri)
             uri = URI.parse(uri) unless uri.is_a?(URI)
             # Note: make sure to keep the full path (if any) from URI::HTTP, for non-ROOT deployments
             # See https://github.com/killbill/killbill/issues/221#issuecomment-151980263
             base_path = uri.request_uri == '/' ? '' : uri.request_uri
-            uri += (base_path + URI::DEFAULT_PARSER.escape(relative_uri))
+            uri += (base_path + encoded_relative_uri)
           else
             uri = encoded_relative_uri
             uri = URI.parse(uri) unless uri.is_a?(URI)


### PR DESCRIPTION
Handle the issue when the URI has already been encoded.