### PR TITLE
feat: add Base64 encoding for Japanese characters in Kill Bill headers

### DIFF
--- a/lib/killbill_client/api/net_http_adapter.rb
+++ b/lib/killbill_client/api/net_http_adapter.rb
@@ -1,6 +1,7 @@
 require 'cgi'
 require 'net/https'
 require 'json'
+require 'base64'
 
 module KillBillClient
   class API
@@ -236,14 +237,27 @@ module KillBillClient
           end
 
           # Add auditing headers, if needed
-          if options[:user]
-            request['X-Killbill-CreatedBy'] = options[:user]
+          encode_header = lambda do |value|
+            return nil if value.nil? || value.to_s.empty
+            Base64.strict_encode64(value.to_s.force_encoding('UTF-8'))
           end
-          if options[:reason]
-            request['X-Killbill-Reason'] = options[:reason]
+
+          encoded_user = encode_header.call(options[:user])
+          encoded_reason = encode_header.call(options[:reason])
+          encoded_comment = encode_header.call(options[:comment])
+
+          if encoded_user
+            request['X-Killbill-CreatedBy'] = encoded_user
           end
-          if options[:comment]
-            request['X-Killbill-Comment'] = options[:comment]
+          if encoded_reason
+            request['X-Killbill-Reason'] = encoded_reason
+          end
+          if encoded_comment
+            request['X-Killbill-Comment'] = encoded_comment
+          end
+          # Add encoding header to indicate Base64 encoding
+          if encoded_user || encoded_reason || encoded_comment
+            request['X-Killbill-Encoding'] = 'base64'
           end
 
           #


### PR DESCRIPTION
- Encode X-Killbill-CreatedBy, X-Killbill-Reason, X-Killbill-Comment in Base64
- Add X-Killbill-Encoding header to indicate Base64 encoding
- Fix Japanese character garbled text issue in KAUI

Changes:
- Modified lib/killbill_client/api/net_http_adapter.rb
- Added encode_header lambda function for UTF-8 to Base64 conversion
- Headers are now Base64 encoded before being sent to Kill Bill server